### PR TITLE
Trim spaces from query

### DIFF
--- a/client.go
+++ b/client.go
@@ -45,7 +45,7 @@ func (c *SeabirdClient) stockCallback(event *pb.CommandEvent) {
 	// TODO: Request debugging
 	log.Printf("Processing event: %s %s %s", event.Source, event.Command, event.Arg)
 
-	query := event.Arg
+	query := strings.TrimSpace(event.Arg)
 
 	profile2, _, err := c.finnhubClient.CompanyProfile2(c.finnhubContext, &finnhub.CompanyProfile2Opts{Symbol: optional.NewString(query)})
 	if err != nil {


### PR DESCRIPTION
Should do the right thing and ensure that any queries with a trailing space are trimmed. 