### PR TITLE
Add basic crypto,exchange,symbols support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 pb/*.pb.go
+.env

--- a/client.go
+++ b/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"math"
+	"sort"
 	"strings"
 	"time"
 
@@ -133,7 +134,10 @@ func (c *SeabirdClient) exchangeCallback(event *pb.CommandEvent) {
 	if err != nil {
 		log.Println(err)
 	}
-	c.MentionReplyf(event.Source, "Supported Exchanges: %v", cryptoExchange)
+
+	sort.Strings(cryptoExchange)
+
+	c.MentionReplyf(event.Source, "Supported Exchanges: %v", strings.Join(cryptoExchange, ", "))
 }
 
 func (c *SeabirdClient) symbolsCallback(event *pb.CommandEvent) {
@@ -142,8 +146,19 @@ func (c *SeabirdClient) symbolsCallback(event *pb.CommandEvent) {
 		log.Println(err)
 		return
 	}
-	fmt.Printf("%+v\n", cryptoSymbol)
-	c.MentionReplyf(event.Source, "Supported Symbols on %s: %v", strings.Title(strings.ToLower(event.Arg)), cryptoSymbol)
+
+	var symbols []string
+	for _, symbol := range cryptoSymbol {
+		symbols = append(symbols, symbol.DisplaySymbol)
+	}
+
+	sort.Strings(symbols)
+
+	c.MentionReplyf(
+		event.Source,
+		"Supported Symbols on %s: %v",
+		strings.Title(strings.ToLower(event.Arg)),
+		strings.Join(symbols, ", "))
 }
 
 func (c *SeabirdClient) cryptoCallback(event *pb.CommandEvent) {

--- a/client.go
+++ b/client.go
@@ -78,6 +78,7 @@ func (c *SeabirdClient) stockCallback(event *pb.CommandEvent) {
 	if err != nil {
 		// TODO: What do we do with the error?
 		log.Println(err)
+		return
 	}
 
 	log.Printf("profile2 is: %+v\n", profile2)
@@ -102,6 +103,7 @@ func (c *SeabirdClient) stockCallback(event *pb.CommandEvent) {
 	if err != nil || quoteResp.ContentLength != -1 {
 		if err != nil {
 			log.Println(err)
+			return
 		}
 		c.MentionReplyf(event.Source, "Unable to find %s.", query)
 	} else {
@@ -126,45 +128,80 @@ func (c *SeabirdClient) stockCallback(event *pb.CommandEvent) {
 
 }
 
+func (c *SeabirdClient) exchangeCallback(event *pb.CommandEvent) {
+	cryptoExchange, _, err := c.finnhubClient.CryptoExchanges(c.finnhubContext)
+	if err != nil {
+		log.Println(err)
+	}
+	c.MentionReplyf(event.Source, "Supported Exchanges: %v", cryptoExchange)
+}
+
+func (c *SeabirdClient) symbolsCallback(event *pb.CommandEvent) {
+	cryptoSymbol, _, err := c.finnhubClient.CryptoSymbols(c.finnhubContext, strings.ToUpper(event.Arg))
+	if err != nil {
+		log.Println(err)
+		return
+	}
+	fmt.Printf("%+v\n", cryptoSymbol)
+	c.MentionReplyf(event.Source, "Supported Symbols on %s: %v", strings.Title(strings.ToLower(event.Arg)), cryptoSymbol)
+}
+
 func (c *SeabirdClient) cryptoCallback(event *pb.CommandEvent) {
-	query := strings.TrimSpace(event.Arg)
+	ticker := strings.ToUpper(strings.TrimSpace(event.Arg))
 	exchange := "COINBASE"
 	currency := "USD"
-	if event.Command == "crypto" {
-		if strings.Contains(query, ":") {
-			// User has specified a specific exchange, just use the original query.
-			// Example: BINANCE:BTCUSDT
-			query = query
-		} else if strings.ContainsAny(query, "/-") {
-			// Fallback to Coinbase but attempt to lookup their requested symbol conversion
-			// TODO(jaredledvina): This is pretty hacky, ideally see if we have an exchange in the query? Would require every request
-			//   to query the exchanges which doesn't seem right....
-			// Example: XLM/EUR
-			query = exchange + query
-		} else {
-			// Fallback to Coinbase and USD when no exchange or conversion is requested
-			query = exchange + query + "-" + currency
-		}
-		// Gets the candle sticks for the last day and returns the Closed price which appears to an accurate current price
-		cryptoCandles, _, err := c.finnhubClient.CryptoCandles(c.finnhubContext, query, "D", time.Now().AddDate(0, 0, -1).Unix(), time.Now().Unix())
-		if err != nil {
-			log.Println(err)
-		}
-		current := cryptoCandles.C
-		c.MentionReplyf(event.Source, "%s - Current: $%.2f on %s", event.Arg, current, strings.Title(strings.ToLower(exchange)))
-	} else if event.Command == "exchange" {
-		cryptoExchange, _, err := c.finnhubClient.CryptoExchanges(c.finnhubContext)
-		if err != nil {
-			log.Println(err)
-		}
-		c.MentionReplyf(event.Source, "Supported Exchanges: %v", cryptoExchange)
-	} else if event.Command == "symbols" {
-		cryptoSymbol, _, err := c.finnhubClient.CryptoSymbols(c.finnhubContext, strings.ToUpper(query))
-		if err != nil {
-			log.Println(err)
-		}
-		c.MentionReplyf(event.Source, "Supported Symbols on %s: %v", strings.Title(strings.ToLower(query)), cryptoSymbol)
+
+	split := strings.SplitN(ticker, ":", 2)
+	if len(split) == 2 {
+		exchange = split[0]
+		ticker = split[1]
 	}
+
+	split = strings.SplitN(ticker, "/", 2)
+	if len(split) == 2 {
+		ticker = split[0]
+		currency = split[1]
+	}
+
+	// TODO: we probably don't need to look this up every time - it should be
+	// fine to cache this and use it later. For now, it's not a huge deal to
+	// have an extra call for every lookup.
+	symbols, _, err := c.finnhubClient.CryptoSymbols(c.finnhubContext, exchange)
+	if err != nil {
+		c.MentionReply(event.Source, "failed to look up exchange symbols")
+		return
+	}
+
+	// Convert from human readable form to internal symbol. This could be more
+	// efficient, but it works for now.
+	var query string
+	target := ticker + "/" + currency
+	for _, symbol := range symbols {
+		if symbol.DisplaySymbol == target {
+			query = symbol.Symbol
+			break
+		}
+	}
+
+	if query == "" {
+		c.MentionReply(event.Source, "ticker or conversion not found on that exchange")
+		return
+	}
+
+	// Gets the candle sticks for the last day and returns the Closed price which appears to an accurate current price
+	cryptoCandles, _, err := c.finnhubClient.CryptoCandles(c.finnhubContext, query, "D", time.Now().AddDate(0, 0, -1).Unix(), time.Now().Unix())
+	if err != nil {
+		log.Println(err)
+		return
+	}
+
+	if len(cryptoCandles.C) == 0 {
+		c.MentionReply(event.Source, "no results")
+		return
+	}
+
+	current := cryptoCandles.C[0]
+	c.MentionReplyf(event.Source, "%s - Current: $%.2f on %s", event.Arg, current, strings.Title(strings.ToLower(exchange)))
 }
 
 // Run runs
@@ -177,8 +214,18 @@ func (c *SeabirdClient) Run() error {
 		},
 		"crypto": {
 			Name:      "crypto",
-			ShortHelp: "<symbol>",
+			ShortHelp: "[<exchange:]<symbol>[/<conversion]",
 			FullHelp:  "Returns current crypto price for given symbol",
+		},
+		"exchange": {
+			Name:      "exchange",
+			ShortHelp: "",
+			FullHelp:  "Returns supported crypto exchanges",
+		},
+		"symbols": {
+			Name:      "symbols",
+			ShortHelp: "<exchange>",
+			FullHelp:  "Returns supported crypto symbols for a given exchange",
 		},
 	})
 	if err != nil {
@@ -192,8 +239,12 @@ func (c *SeabirdClient) Run() error {
 			switch v.Command.Command {
 			case "stock", "stocks", "stonk", "stonks":
 				go c.stockCallback(v.Command)
-			case "crypto", "exchange", "symbols":
+			case "crypto":
 				go c.cryptoCallback(v.Command)
+			case "exchange":
+				go c.exchangeCallback(v.Command)
+			case "symbols":
+				go c.symbolsCallback(v.Command)
 			}
 		}
 	}


### PR DESCRIPTION
Notably, this is based off of https://github.com/seabird-chat/seabird-stock-plugin/pull/5 so that should go in first but, this adds `crypto`, `exchange`, and `symbols` as commands to seabird. 

`crypto` will default to Coinbase and USD if you just ask for a ticker, but can attempt to do other conversions and use other exchanges. `exchange` will return all of Finnhubb's support exchanges and `symbols` takes an exchanges and tries to return all of that exchanges supported symbols. 

It's not great but, as a late night hack project, is working. 